### PR TITLE
fix flixel 6.0.0+ compatibility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
         "editor.codeActionsOnSave": {
             "source.organizeImports": "always"
         }
-    }
+    },
     "haxe.configurations": [
 		{
 			"label": "windows",

--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,3 +1,3 @@
 --macro addMetadata('@:build(modchart.backend.macros.Macro.buildFlxCamera())', 'flixel.FlxCamera')
 --macro addMetadata('@:build(modchart.backend.macros.Macro.buildFlxDrawTrianglesItem())', 'flixel.graphics.tile.FlxDrawTrianglesItem')
---macro addMetadata('@:build(modchart.backend.macros.Macro.addModchartStorage())', 'flixel.FlxObject')
+--macro addMetadata('@:build(modchart.backend.macros.Macro.addModchartStorage())', 'flixel.FlxBasic')

--- a/modchart/Manager.hx
+++ b/modchart/Manager.hx
@@ -252,11 +252,14 @@ final class Manager extends FlxBasic {
 		});
 
 		drawQueue.sort((a, b) -> {
+			if (a == null || b == null)
+				return 0;
 			return FlxSort.byValues(FlxSort.DESCENDING, a.z, b.z);
 		});
 
 		for (item in drawQueue) {
-			item.callback();
+			if (item != null)
+				item.callback();
 		}
 	}
 

--- a/modchart/Manager.hx
+++ b/modchart/Manager.hx
@@ -252,15 +252,11 @@ final class Manager extends FlxBasic {
 		});
 
 		drawQueue.sort((a, b) -> {
-			if (a == null || b == null)
-				return 0;
 			return FlxSort.byValues(FlxSort.DESCENDING, a.z, b.z);
 		});
 
-		for (item in drawQueue) {
-			if (item != null)
-				item.callback();
-		}
+		for (item in drawQueue)
+			item.callback();
 	}
 
 	/**

--- a/modchart/backend/graphics/renderers/ModchartArrowRenderer.hx
+++ b/modchart/backend/graphics/renderers/ModchartArrowRenderer.hx
@@ -9,7 +9,7 @@ final helperVector = new Vector3();
 @:fileXml('tags="haxe,release"')
 @:noDebug
 #end
-#if (flixel < "6.0.0")
+#if (flixel < "6.1.0")
 import modchart.backend.util.ModchartUtil.FlxUVRect;
 #end
 final class ModchartArrowRenderer extends ModchartRenderer<FlxSprite> {
@@ -146,7 +146,7 @@ final class ModchartArrowRenderer extends ModchartRenderer<FlxSprite> {
 			planeVertices[4], planeVertices[5], // top left
 			planeVertices[6], planeVertices[7] // bottom right
 		]);
-		#if (flixel < "6.0.0")
+		#if (flixel < "6.1.0")
 		final uvRectangle:FlxUVRect = cast arrow.frame.uv;
 		#else
 		final uvRectangle = arrow.frame.uv;

--- a/modchart/backend/graphics/renderers/ModchartArrowRenderer.hx
+++ b/modchart/backend/graphics/renderers/ModchartArrowRenderer.hx
@@ -9,6 +9,9 @@ final helperVector = new Vector3();
 @:fileXml('tags="haxe,release"')
 @:noDebug
 #end
+#if (flixel < "6.0.0")
+import modchart.backend.util.ModchartUtil.FlxUVRect;
+#end
 final class ModchartArrowRenderer extends ModchartRenderer<FlxSprite> {
 	inline private function getGraphicVertices(planeWidth:Float, planeHeight:Float, flipX:Bool, flipY:Bool) {
 		var x1 = flipX ? planeWidth : -planeWidth;
@@ -143,16 +146,20 @@ final class ModchartArrowRenderer extends ModchartRenderer<FlxSprite> {
 			planeVertices[4], planeVertices[5], // top left
 			planeVertices[6], planeVertices[7] // bottom right
 		]);
+		#if (flixel < "6.0.0")
+		final uvRectangle:FlxUVRect = cast arrow.frame.uv;
+		#else
 		final uvRectangle = arrow.frame.uv;
+		#end
 		var uvData = new DrawData<Float>(18, true, [
 			// uv for triangle 1
-			uvRectangle.x,      uvRectangle.y,      1 / projectionZ[0], // top left
-			uvRectangle.width,  uvRectangle.y,      1 / projectionZ[1], // top right
-			uvRectangle.width,  uvRectangle.height, 1 / projectionZ[3], // bottom left
+			uvRectangle.left, uvRectangle.right,  1 / projectionZ[0], // top left
+			uvRectangle.top,  uvRectangle.right,  1 / projectionZ[1], // top right
+			uvRectangle.top,  uvRectangle.bottom, 1 / projectionZ[3], // bottom left
 			// uv for triangle 2
-			uvRectangle.x,      uvRectangle.y,      1 / projectionZ[0], // top right
-			uvRectangle.x,      uvRectangle.height, 1 / projectionZ[2], // top left
-			uvRectangle.width,  uvRectangle.height, 1 / projectionZ[3]  // bottom right
+			uvRectangle.left, uvRectangle.right,  1 / projectionZ[0], // top right
+			uvRectangle.left, uvRectangle.bottom, 1 / projectionZ[2], // top left
+			uvRectangle.top,  uvRectangle.bottom, 1 / projectionZ[3]  // bottom right
 		]);
         // @formatter:on
 		final absGlow = output.visuals.glow * 255;

--- a/modchart/backend/graphics/renderers/ModchartArrowRenderer.hx
+++ b/modchart/backend/graphics/renderers/ModchartArrowRenderer.hx
@@ -9,9 +9,6 @@ final helperVector = new Vector3();
 @:fileXml('tags="haxe,release"')
 @:noDebug
 #end
-#if (flixel < "6.1.0")
-import modchart.backend.util.ModchartUtil.FlxUVRect;
-#end
 final class ModchartArrowRenderer extends ModchartRenderer<FlxSprite> {
 	inline private function getGraphicVertices(planeWidth:Float, planeHeight:Float, flipX:Bool, flipY:Bool) {
 		var x1 = flipX ? planeWidth : -planeWidth;
@@ -146,12 +143,9 @@ final class ModchartArrowRenderer extends ModchartRenderer<FlxSprite> {
 			planeVertices[4], planeVertices[5], // top left
 			planeVertices[6], planeVertices[7] // bottom right
 		]);
-		#if (flixel < "6.1.0")
-		final uvRectangle:FlxUVRect = cast arrow.frame.uv;
-		#else
 		final uvRectangle = arrow.frame.uv;
-		#end
 		var uvData = new DrawData<Float>(18, true, [
+			#if (flixel >= "6.1.0")
 			// uv for triangle 1
 			uvRectangle.left, uvRectangle.right,  1 / projectionZ[0], // top left
 			uvRectangle.top,  uvRectangle.right,  1 / projectionZ[1], // top right
@@ -160,6 +154,16 @@ final class ModchartArrowRenderer extends ModchartRenderer<FlxSprite> {
 			uvRectangle.left, uvRectangle.right,  1 / projectionZ[0], // top right
 			uvRectangle.left, uvRectangle.bottom, 1 / projectionZ[2], // top left
 			uvRectangle.top,  uvRectangle.bottom, 1 / projectionZ[3]  // bottom right
+			#else
+			// uv for triangle 1
+			uvRectangle.x,     uvRectangle.y,      1 / projectionZ[0], // top left
+			uvRectangle.width, uvRectangle.y,      1 / projectionZ[1], // top right
+			uvRectangle.width, uvRectangle.height, 1 / projectionZ[3], // bottom left
+			// uv for triangle 2
+			uvRectangle.x,      uvRectangle.y,      1 / projectionZ[0], // top right
+			uvRectangle.x,      uvRectangle.height, 1 / projectionZ[2], // top left
+			uvRectangle.width,  uvRectangle.height, 1 / projectionZ[3]  // bottom right
+			#end
 		]);
         // @formatter:on
 		final absGlow = output.visuals.glow * 255;

--- a/modchart/backend/graphics/renderers/ModchartHoldRenderer.hx
+++ b/modchart/backend/graphics/renderers/ModchartHoldRenderer.hx
@@ -273,7 +273,7 @@ final class ModchartHoldRenderer extends ModchartRenderer<FlxSprite> {
 		newInstruction.item = item;
 		newInstruction.vertices = vertices;
 		newInstruction.indices = _indices;
-		newInstruction.uvt = ModchartUtil.getHoldUVT(item, HOLD_SUBDIVISIONS, isHoldEnd);
+		newInstruction.uvt = ModchartUtil.getHoldUVT(item, HOLD_SUBDIVISIONS);
 		newInstruction.colorData = transfTotal;
 		newInstruction.extra = [alphaTotal];
 

--- a/modchart/backend/graphics/renderers/ModchartHoldRenderer.hx
+++ b/modchart/backend/graphics/renderers/ModchartHoldRenderer.hx
@@ -273,7 +273,7 @@ final class ModchartHoldRenderer extends ModchartRenderer<FlxSprite> {
 		newInstruction.item = item;
 		newInstruction.vertices = vertices;
 		newInstruction.indices = _indices;
-		newInstruction.uvt = ModchartUtil.getHoldUVT(item, HOLD_SUBDIVISIONS);
+		newInstruction.uvt = ModchartUtil.getHoldUVT(item, HOLD_SUBDIVISIONS, isHoldEnd);
 		newInstruction.colorData = transfTotal;
 		newInstruction.extra = [alphaTotal];
 

--- a/modchart/backend/macros/Macro.macro.hx
+++ b/modchart/backend/macros/Macro.macro.hx
@@ -15,16 +15,16 @@ class Macro {
 	public static function addModchartStorage():Array<Field> {
 		final fields = Context.getBuildFields();
 		final pos = Context.currentPos();
-
+		
 		for (f in fields) {
 			if (f.name == 'set_visible') {
 				switch (f.kind) {
 					case FFun(fun):
 						fun.expr = macro {
-							visible = value;
-							_fmVisible = value;
+							visible = Value;
+							_fmVisible = Value;
 
-							return value;
+							return Value;
 						};
 					default:
 						// do nothing

--- a/modchart/backend/util/ModchartUtil.hx
+++ b/modchart/backend/util/ModchartUtil.hx
@@ -104,13 +104,17 @@ using StringTools;
 		else
 			uv = new DrawData<Float>(8 * subs, true, []);
 
-		#if (flixel < "6.1.0")
-		var frameUV:FlxUVRect = cast arrow.frame.uv;
-		#else
 		var frameUV = arrow.frame.uv;
-		#end
-		var frameWidth = frameUV.top - frameUV.left;
-		var frameHeight = frameUV.bottom - frameUV.right;
+
+		// i do not like this
+		// but i was suggested to do this instead by theo -swordcube
+		var left = #if (flixel >= "6.1.0") frameUV.left #else frameUV.x #end;
+		var right = #if (flixel >= "6.1.0") frameUV.right #else frameUV.y #end;
+		var top = #if (flixel >= "6.1.0") frameUV.top #else frameUV.width #end;
+		var bottom = #if (flixel >= "6.1.0") frameUV.bottom #else frameUV.height #end;
+
+		var frameWidth = top - left;
+		var frameHeight = bottom - right;
 
 		var subDivided = 1.0 / subs;
 
@@ -120,10 +124,10 @@ using StringTools;
 				var uvOffset = subDivided * curSub;
 				var subIndex = curSub * 8;
 
-				uv[subIndex] = uv[subIndex + 4] = frameUV.left;
-				uv[subIndex + 2] = uv[subIndex + 6] = frameUV.top;
-				uv[subIndex + 1] = uv[subIndex + 3] = frameUV.right + uvOffset * frameHeight;
-				uv[subIndex + 5] = uv[subIndex + 7] = frameUV.right + (uvOffset + subDivided) * frameHeight;
+				uv[subIndex] = uv[subIndex + 4] = left;
+				uv[subIndex + 2] = uv[subIndex + 6] = top;
+				uv[subIndex + 1] = uv[subIndex + 3] = right + uvOffset * frameHeight;
+				uv[subIndex + 5] = uv[subIndex + 7] = right + (uvOffset + subDivided) * frameHeight;
 			}
 			return uv;
 		}
@@ -132,8 +136,8 @@ using StringTools;
 		var cosA = ModchartUtil.cos(angleRad);
 		var sinA = ModchartUtil.sin(angleRad);
 
-		var uCenter = frameUV.left + frameWidth * .5;
-		var vCenter = frameUV.right + frameHeight * .5;
+		var uCenter = left + frameWidth * .5;
+		var vCenter = right + frameHeight * .5;
 
 		// my brain is not braining anymore
 		// i give up
@@ -143,10 +147,10 @@ using StringTools;
 
 			// uv coords before rotation
 			var uvCoords = [
-				[frameUV.left, frameUV.right + uvOffset * frameHeight], // tl
-				[frameUV.top, frameUV.right + uvOffset * frameHeight], // tr
-				[frameUV.left, frameUV.right + (uvOffset + subDivided) * frameHeight], // bl
-				[frameUV.top, frameUV.right + (uvOffset + subDivided) * frameHeight] // br
+				[left, right + uvOffset * frameHeight], // tl
+				[top, right + uvOffset * frameHeight], // tr
+				[left, right + (uvOffset + subDivided) * frameHeight], // bl
+				[top, right + (uvOffset + subDivided) * frameHeight] // br
 			];
 
 			// apply rotation
@@ -230,52 +234,3 @@ using StringTools;
 		];
 	}
 }
-
-#if (flixel < "6.1.0")
-/**
- * FlxRect, but instead of `x`, `y`, `width` and `height`, it takes a `left`, `right`, `top` and
- * `bottom`. This is for optimization reasons, to reduce arithmetic when drawing vertices
- */
-@:forward(put)
-abstract FlxUVRect(FlxRect) from FlxRect to flixel.util.FlxPool.IFlxPooled
-{
-	public var left(get, set):Float;
-	inline function get_left():Float { return this.x; }
-	inline function set_left(value):Float { return this.x = value; }
-	
-	/** Top */
-	public var right(get, set):Float;
-	inline function get_right():Float { return this.y; }
-	inline function set_right(value):Float { return this.y = value; }
-	
-	/** Right */
-	public var top(get, set):Float;
-	inline function get_top():Float { return this.width; }
-	inline function set_top(value):Float { return this.width = value; }
-	
-	/** Bottom */
-	public var bottom(get, set):Float;
-	inline function get_bottom():Float { return this.height; }
-	inline function set_bottom(value):Float { return this.height = value; }
-	
-	public inline function set(l, t, r, b)
-	{
-		this.set(l, t, r, b);
-	}
-	
-	public inline function copyTo(uv:FlxUVRect)
-	{
-		uv.set(left, top, right, bottom);
-	}
-	
-	public inline function copyFrom(uv:FlxUVRect)
-	{
-		set(uv.left, uv.top, uv.right, uv.bottom);
-	}
-	
-	public static function get(l = 0.0, t = 0.0, r = 0.0, b = 0.0)
-	{
-		return FlxRect.get(l, t, r, b);
-	}
-}
-#end

--- a/modchart/backend/util/ModchartUtil.hx
+++ b/modchart/backend/util/ModchartUtil.hx
@@ -94,7 +94,7 @@ using StringTools;
 		}
 	}
 
-	inline static public function getHoldUVT(arrow:FlxSprite, subs:Int, isHoldEnd:Bool, ?vector:DrawData<Float>) {
+	inline static public function getHoldUVT(arrow:FlxSprite, subs:Int, ?vector:DrawData<Float>) {
 		var frameAngle = -ModchartUtil.getFrameAngle(arrow);
 
 		var uv:DrawData<Float> = null;
@@ -109,10 +109,8 @@ using StringTools;
 		#else
 		var frameUV = arrow.frame.uv;
 		#end
-		var bleedingFix = (!isHoldEnd) ? 0.001 : 0;
-
 		var frameWidth = frameUV.top - frameUV.left;
-		var frameHeight = Math.max((frameUV.bottom - frameUV.right) - (bleedingFix * 2), 0); // fix texture bleeding??
+		var frameHeight = frameUV.bottom - frameUV.right;
 
 		var subDivided = 1.0 / subs;
 
@@ -123,9 +121,9 @@ using StringTools;
 				var subIndex = curSub * 8;
 
 				uv[subIndex] = uv[subIndex + 4] = frameUV.left;
-				uv[subIndex + 2] = uv[subIndex + 6] = frameUV.top; // fix texture bleeding??
-				uv[subIndex + 1] = uv[subIndex + 3] = (frameUV.right + bleedingFix) + uvOffset * frameHeight;
-				uv[subIndex + 5] = uv[subIndex + 7] = (frameUV.right + bleedingFix) + (uvOffset + subDivided) * frameHeight;
+				uv[subIndex + 2] = uv[subIndex + 6] = frameUV.top;
+				uv[subIndex + 1] = uv[subIndex + 3] = frameUV.right + uvOffset * frameHeight;
+				uv[subIndex + 5] = uv[subIndex + 7] = frameUV.right + (uvOffset + subDivided) * frameHeight;
 			}
 			return uv;
 		}
@@ -159,8 +157,8 @@ using StringTools;
 				var uRot = u * cosA - v * sinA;
 				var vRot = u * sinA + v * cosA;
 
-				uv[subIndex + i * 2] = (uRot + uCenter) + bleedingFix; // fix texture bleeding??
-				uv[subIndex + i * 2 + 1] = (vRot + vCenter) + bleedingFix; // fix texture bleeding??
+				uv[subIndex + i * 2] = uRot + uCenter;
+				uv[subIndex + i * 2 + 1] = vRot + vCenter;
 			}
 		}
 

--- a/modchart/backend/util/ModchartUtil.hx
+++ b/modchart/backend/util/ModchartUtil.hx
@@ -24,7 +24,7 @@ using StringTools;
 		// 	case ANGLE_270 | ANGLE_NEG_90: 270;
 		// 	default: 0; // ANGLE_0d
 		// }
-		return cast spr.frame.angle; // We can just do this, prevents a deprecation warning too!
+		return cast spr.frame.angle; // We can just do this, prevents an unused case warning too!
 	}
 
 	@:pure @:noDebug

--- a/modchart/backend/util/ModchartUtil.hx
+++ b/modchart/backend/util/ModchartUtil.hx
@@ -104,7 +104,7 @@ using StringTools;
 		else
 			uv = new DrawData<Float>(8 * subs, true, []);
 
-		#if (flixel < "6.0.0")
+		#if (flixel < "6.1.0")
 		var frameUV:FlxUVRect = cast arrow.frame.uv;
 		#else
 		var frameUV = arrow.frame.uv;
@@ -233,7 +233,7 @@ using StringTools;
 	}
 }
 
-#if (flixel < "6.0.0")
+#if (flixel < "6.1.0")
 /**
  * FlxRect, but instead of `x`, `y`, `width` and `height`, it takes a `left`, `right`, `top` and
  * `bottom`. This is for optimization reasons, to reduce arithmetic when drawing vertices

--- a/modchart/backend/util/ModchartUtil.hx
+++ b/modchart/backend/util/ModchartUtil.hx
@@ -19,11 +19,12 @@ using StringTools;
 	// pain (we need this if we want support for sprite sheet packer)
 	@:pure
 	inline public static function getFrameAngle(spr:FlxSprite):Float {
-		return switch (spr.frame.angle) {
-			case ANGLE_90: 90;
-			case ANGLE_270 | ANGLE_NEG_90: 270;
-			default: 0; // ANGLE_0d
-		}
+		// return switch (spr.frame.angle) {
+		// 	case ANGLE_90: 90;
+		// 	case ANGLE_270 | ANGLE_NEG_90: 270;
+		// 	default: 0; // ANGLE_0d
+		// }
+		return cast spr.frame.angle; // We can just do this, prevents a deprecation warning too!
 	}
 
 	@:pure @:noDebug
@@ -93,7 +94,7 @@ using StringTools;
 		}
 	}
 
-	inline static public function getHoldUVT(arrow:FlxSprite, subs:Int, ?vector:DrawData<Float>) {
+	inline static public function getHoldUVT(arrow:FlxSprite, subs:Int, isHoldEnd:Bool, ?vector:DrawData<Float>) {
 		var frameAngle = -ModchartUtil.getFrameAngle(arrow);
 
 		var uv:DrawData<Float> = null;
@@ -108,8 +109,10 @@ using StringTools;
 		#else
 		var frameUV = arrow.frame.uv;
 		#end
+		var bleedingFix = (!isHoldEnd) ? 0.001 : 0;
+
 		var frameWidth = frameUV.top - frameUV.left;
-		var frameHeight = frameUV.bottom - frameUV.right;
+		var frameHeight = Math.max((frameUV.bottom - frameUV.right) - (bleedingFix * 2), 0); // fix texture bleeding??
 
 		var subDivided = 1.0 / subs;
 
@@ -120,9 +123,9 @@ using StringTools;
 				var subIndex = curSub * 8;
 
 				uv[subIndex] = uv[subIndex + 4] = frameUV.left;
-				uv[subIndex + 2] = uv[subIndex + 6] = frameUV.top;
-				uv[subIndex + 1] = uv[subIndex + 3] = frameUV.right + uvOffset * frameHeight;
-				uv[subIndex + 5] = uv[subIndex + 7] = frameUV.right + (uvOffset + subDivided) * frameHeight;
+				uv[subIndex + 2] = uv[subIndex + 6] = frameUV.top; // fix texture bleeding??
+				uv[subIndex + 1] = uv[subIndex + 3] = (frameUV.right + bleedingFix) + uvOffset * frameHeight;
+				uv[subIndex + 5] = uv[subIndex + 7] = (frameUV.right + bleedingFix) + (uvOffset + subDivided) * frameHeight;
 			}
 			return uv;
 		}
@@ -156,8 +159,8 @@ using StringTools;
 				var uRot = u * cosA - v * sinA;
 				var vRot = u * sinA + v * cosA;
 
-				uv[subIndex + i * 2] = uRot + uCenter;
-				uv[subIndex + i * 2 + 1] = vRot + vCenter;
+				uv[subIndex + i * 2] = (uRot + uCenter) + bleedingFix; // fix texture bleeding??
+				uv[subIndex + i * 2 + 1] = (vRot + vCenter) + bleedingFix; // fix texture bleeding??
 			}
 		}
 

--- a/modchart/backend/util/ModchartUtil.hx
+++ b/modchart/backend/util/ModchartUtil.hx
@@ -5,6 +5,7 @@ import flixel.FlxSprite;
 import flixel.graphics.tile.FlxDrawTrianglesItem.DrawData;
 import flixel.math.FlxAngle;
 import flixel.math.FlxMath;
+import flixel.math.FlxRect;
 import haxe.ds.Vector;
 import openfl.geom.Matrix3D;
 

--- a/modchart/backend/util/ModchartUtil.hx
+++ b/modchart/backend/util/ModchartUtil.hx
@@ -102,9 +102,13 @@ using StringTools;
 		else
 			uv = new DrawData<Float>(8 * subs, true, []);
 
+		#if (flixel < "6.0.0")
+		var frameUV:FlxUVRect = cast arrow.frame.uv;
+		#else
 		var frameUV = arrow.frame.uv;
-		var frameWidth = frameUV.width - frameUV.x;
-		var frameHeight = frameUV.height - frameUV.y;
+		#end
+		var frameWidth = frameUV.top - frameUV.left;
+		var frameHeight = frameUV.bottom - frameUV.right;
 
 		var subDivided = 1.0 / subs;
 
@@ -114,10 +118,10 @@ using StringTools;
 				var uvOffset = subDivided * curSub;
 				var subIndex = curSub * 8;
 
-				uv[subIndex] = uv[subIndex + 4] = frameUV.x;
-				uv[subIndex + 2] = uv[subIndex + 6] = frameUV.width;
-				uv[subIndex + 1] = uv[subIndex + 3] = frameUV.y + uvOffset * frameHeight;
-				uv[subIndex + 5] = uv[subIndex + 7] = frameUV.y + (uvOffset + subDivided) * frameHeight;
+				uv[subIndex] = uv[subIndex + 4] = frameUV.left;
+				uv[subIndex + 2] = uv[subIndex + 6] = frameUV.top;
+				uv[subIndex + 1] = uv[subIndex + 3] = frameUV.right + uvOffset * frameHeight;
+				uv[subIndex + 5] = uv[subIndex + 7] = frameUV.right + (uvOffset + subDivided) * frameHeight;
 			}
 			return uv;
 		}
@@ -126,8 +130,8 @@ using StringTools;
 		var cosA = ModchartUtil.cos(angleRad);
 		var sinA = ModchartUtil.sin(angleRad);
 
-		var uCenter = frameUV.x + frameWidth * .5;
-		var vCenter = frameUV.y + frameHeight * .5;
+		var uCenter = frameUV.left + frameWidth * .5;
+		var vCenter = frameUV.right + frameHeight * .5;
 
 		// my brain is not braining anymore
 		// i give up
@@ -137,10 +141,10 @@ using StringTools;
 
 			// uv coords before rotation
 			var uvCoords = [
-				[frameUV.x, frameUV.y + uvOffset * frameHeight], // tl
-				[frameUV.width, frameUV.y + uvOffset * frameHeight], // tr
-				[frameUV.x, frameUV.y + (uvOffset + subDivided) * frameHeight], // bl
-				[frameUV.width, frameUV.y + (uvOffset + subDivided) * frameHeight] // br
+				[frameUV.left, frameUV.right + uvOffset * frameHeight], // tl
+				[frameUV.top, frameUV.right + uvOffset * frameHeight], // tr
+				[frameUV.left, frameUV.right + (uvOffset + subDivided) * frameHeight], // bl
+				[frameUV.top, frameUV.right + (uvOffset + subDivided) * frameHeight] // br
 			];
 
 			// apply rotation
@@ -224,3 +228,52 @@ using StringTools;
 		];
 	}
 }
+
+#if (flixel < "6.0.0")
+/**
+ * FlxRect, but instead of `x`, `y`, `width` and `height`, it takes a `left`, `right`, `top` and
+ * `bottom`. This is for optimization reasons, to reduce arithmetic when drawing vertices
+ */
+@:forward(put)
+abstract FlxUVRect(FlxRect) from FlxRect to flixel.util.FlxPool.IFlxPooled
+{
+	public var left(get, set):Float;
+	inline function get_left():Float { return this.x; }
+	inline function set_left(value):Float { return this.x = value; }
+	
+	/** Top */
+	public var right(get, set):Float;
+	inline function get_right():Float { return this.y; }
+	inline function set_right(value):Float { return this.y = value; }
+	
+	/** Right */
+	public var top(get, set):Float;
+	inline function get_top():Float { return this.width; }
+	inline function set_top(value):Float { return this.width = value; }
+	
+	/** Bottom */
+	public var bottom(get, set):Float;
+	inline function get_bottom():Float { return this.height; }
+	inline function set_bottom(value):Float { return this.height = value; }
+	
+	public inline function set(l, t, r, b)
+	{
+		this.set(l, t, r, b);
+	}
+	
+	public inline function copyTo(uv:FlxUVRect)
+	{
+		uv.set(left, top, right, bottom);
+	}
+	
+	public inline function copyFrom(uv:FlxUVRect)
+	{
+		set(uv.left, uv.top, uv.right, uv.bottom);
+	}
+	
+	public static function get(l = 0.0, t = 0.0, r = 0.0, b = 0.0)
+	{
+		return FlxRect.get(l, t, r, b);
+	}
+}
+#end


### PR DESCRIPTION
flixel 6.0.0+ uses FlxUVRect instead of FlxRect for frame UVs, this prevents you from using x, y, width and height, and you must use the replacements of left, right, top and bottom instead

also made the FlxObject visible macro stuff apply to FlxBasic instead, since it appears to not work otherwise