### PR TITLE
CNE Invisible Strumline Fix + Draw Sustain Behind Strums

### DIFF
--- a/modchart/Config.hx
+++ b/modchart/Config.hx
@@ -102,6 +102,13 @@ class Config {
 	 * Default: `true`
 	 */
 	public static var COLUMN_SPECIFIC_MODIFIERS:Bool = true;
+
+	/**
+	 * Shows the sustains behind the strums
+	 * 
+	 * Default `false`
+	 */
+	public static var HOLDS_BEHIND_STRUM:Bool = false;
 }
 
 typedef ArrowPathConfig = {
@@ -128,7 +135,7 @@ typedef ArrowPathConfig = {
 	APPLY_SCALE:Bool,
 
 	/**
-	 * "Resulution" multiplier of arrow paths.
+	 * "Resolution" multiplier of arrow paths.
 	 * Higher value = More divisions = Smoother path.
 	 * **WARNING**: Can't be zero or it will CRASH.
 	 */

--- a/modchart/engine/PlayField.hx
+++ b/modchart/engine/PlayField.hx
@@ -270,6 +270,27 @@ final class PlayField extends FlxSprite {
 		for (i in 0...playerItems.length) {
 			var curItems:Array<Array<FlxSprite>> = playerItems[i];
 
+			if (curItems == null || curItems.length == 0) continue;
+
+			final drawHolds = () -> {
+				if (holdLength > 0) {
+					for (hold in curItems[2]) {
+						if (!getVisibility(hold))
+							continue;
+
+						holdRenderer.prepare(hold);
+						queue({
+							callback: holdRenderer.shift,
+							z: hold._z
+						});
+					}
+				}
+			};
+
+			//holds (behind strums)
+			if (Config.HOLDS_BEHIND_STRUM)
+				drawHolds();
+			
 			// receptors
 			if (receptorLength > 0) {
 				for (receptor in curItems[0]) {
@@ -286,19 +307,9 @@ final class PlayField extends FlxSprite {
 				}
 			}
 
-			// holds
-			if (holdLength > 0) {
-				for (hold in curItems[2]) {
-					if (!getVisibility(hold))
-						continue;
-
-					holdRenderer.prepare(hold);
-					queue({
-						callback: holdRenderer.shift,
-						z: hold._z
-					});
-				}
-			}
+			// holds (infront of strums)
+			if (!Config.HOLDS_BEHIND_STRUM)
+				drawHolds();
 
 			// tap arrow
 			if (arrowLength > 0) {


### PR DESCRIPTION
[Codename Engine Only] Invisible Strumlines no longer crashes with a Modchart Manager running

[All Engines] Added a `HOLDS_BEHIND_STRUM` field in `Config.hx` to change if sustains are in front of behind the strums since some modifiers have some weird clipping and having the strums behind could hide that problem