### PR TITLE
Fix hold arrow gaps on Psych target

### DIFF
--- a/modchart/backend/standalone/adapters/psych/Psych.hx
+++ b/modchart/backend/standalone/adapters/psych/Psych.hx
@@ -32,7 +32,7 @@ class Psych implements IAdapter {
 	}
 
 	public function onModchartingInitialization() {
-		__fCrochet = (Conductor.crochet + 8) / 4;
+		__fCrochet = (Conductor.crochet) / 4;
 	}
 
 	private function setupLuaFunctions() {


### PR DESCRIPTION
without my changes:

<img width="355" height="541" alt="image" src="https://github.com/user-attachments/assets/5ac37073-a9e6-469f-8d1b-cdee1cf4dce2" />


with my changes:

<img width="355" height="541" alt="image" src="https://github.com/user-attachments/assets/b42034c7-7a62-4993-8d17-7d2a7916992d" />

sorry for the flood-
