### PR TITLE
Fix Bumpy.hx, ReceptorScroll.hx and Radionic.hx modifiers

### DIFF
--- a/modchart/engine/modifiers/list/Bumpy.hx
+++ b/modchart/engine/modifiers/list/Bumpy.hx
@@ -29,9 +29,12 @@ class Bumpy extends Modifier {
 
 		var shift = 0.;
 
-		var angle = 40 * sin(distance + (100 * offset)) / ((period * 24) + 24);
+		var scrollSpeed = getScrollSpeed();
 
-		shift += (getPercent('bumpy' + axis, player) + getPercent('bumpy' + axis + receptorName, player)) * angle;
+		var bumpyMath = 40 * sin(((distance * 0.01) + (100.0 * offset) / ((period * (mult * 24.0)) +
+			24.0)) / ((scrollSpeed * mult) / 2)) * (getKeyCount() / 2.0);
+
+		shift += (getPercent('bumpy' + axis, player) + getPercent('bumpy' + axis + receptorName, player)) * bumpyMath;
 
 		switch (realAxis) {
 			case 'x':

--- a/modchart/engine/modifiers/list/Radionic.hx
+++ b/modchart/engine/modifiers/list/Radionic.hx
@@ -38,6 +38,10 @@ class Radionic extends Modifier {
 
 	override public function visuals(data:VisualParameters, params:ModifierParameters):VisualParameters {
 		final perc = getPercent('radionic', params.player);
+
+		if (perc == 0)
+			return data;
+		
 		final amount = 0.6;
 
 		data.scaleX = perc * (data.scaleY = 1 + amount - FlxEase.cubeOut((params.curBeat - Math.floor(params.curBeat))) * amount);

--- a/modchart/engine/modifiers/list/ReceptorScroll.hx
+++ b/modchart/engine/modifiers/list/ReceptorScroll.hx
@@ -38,12 +38,17 @@ class ReceptorScroll extends Modifier {
 		if (perc == 0)
 			return data;
 
-		var bar = params.songTime / (Adapter.instance.getCurrentCrochet() * .25);
-		var hitTime = params.distance;
-
-		data.alpha = FlxMath.bound((1400 - hitTime) / 200, 0, 0.3) * perc;
-		if ((params.distance + params.songTime) < Math.floor(bar + 1) * Adapter.instance.getCurrentCrochet() * 4)
-			data.alpha = 1;
+		final moveSpeed = Adapter.instance.getCurrentCrochet() * 4;
+		var songTime = Adapter.instance.getSongPosition();
+		var currentCycle = Math.floor(songTime / moveSpeed) % 2;
+		var noteTime = songTime + params.distance;
+		var noteCycle = Math.floor(noteTime / moveSpeed) % 2;
+		
+		if (currentCycle == noteCycle) {
+			data.alpha = 1.0;
+		} else {
+			data.alpha = 0.3;
+		}
 
 		return data;
 	}


### PR DESCRIPTION
Meh da flojera hablar ingles, habia un problema que hacia que bumpy saltara muchas veces y se viera mal el modifier, lo arregle; tambien habia otro que cuando se usaba radionic, no aparecian las notas aunque no se usaba todavia, y en ReceptorScroll arregle la calculacion de alpha, verificalo.